### PR TITLE
Validate websocket messages

### DIFF
--- a/sonos_websocket/websocket.py
+++ b/sonos_websocket/websocket.py
@@ -104,7 +104,7 @@ class SonosWebsocket:
                 if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
                     _LOGGER.debug("Websocket closed, will try again")
                 elif msg.type != WSMsgType.TEXT:
-                    _LOGGER.error("Received non-text message: %s", msg)
+                    _LOGGER.error("Received non-text message: %s", msg.type.name)
                 else:
                     return msg.json()
             attempt += 1


### PR DESCRIPTION
This should clean up the handling when the websocket is unexpectedly closed and avoid printing inscrutable errors like:
```
Bad response received: Received message 8:1000 is not str
```