### PR TITLE
Provides a tuneable argument 'timeout' for the web socket

### DIFF
--- a/sonos_websocket/__main__.py
+++ b/sonos_websocket/__main__.py
@@ -10,7 +10,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 async def main(options):
     """Entrypoint when running as a script."""
-    websocket = SonosWebsocket(options.ip_addr)
+    websocket = SonosWebsocket(options.ip_addr, timeout=options.timeout)
     await websocket.connect()
     await websocket.play_clip(
         uri=options.uri,
@@ -33,6 +33,13 @@ if __name__ == "__main__":
         type=int,
         required=False,
         help="Volume level to play at [0-100]",
+    )
+    parser.add_argument(
+        "--timeout",
+        "-t",
+        type=int,
+        required=False,
+        help="Timeout for the websocket connection",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
As described in #7 the wss connect timeout can sometimes be a little low. I'm unsure why, but it isn't a network stability issue as suggested in the existing issue.

This patch will allow upstream consumers of the library to be less aggressive with the timeouts should they want to be, but I've left the default at 3 seconds for consistency. 

